### PR TITLE
This patch makes it possible to reboot mi by mqtt and web.

### DIFF
--- a/include/base/webserver.h
+++ b/include/base/webserver.h
@@ -62,6 +62,7 @@ private:
     static void handleUpdateBindingsSettings(AsyncWebServerRequest *request);
     static void handleUpdatePowerLimit(AsyncWebServerRequest *request);
     static void handleGetWifiNetworks(AsyncWebServerRequest *request);
+    static void handleRebootMi(AsyncWebServerRequest *request);
 
     static void handleUpdateOTASettings(AsyncWebServerRequest *request);
     static void handleUpdateInfoRequest(AsyncWebServerRequest *request);

--- a/include/dtuInterface.h
+++ b/include/dtuInterface.h
@@ -40,6 +40,7 @@
 #define DTU_STATE_DTU_REBOOT 4
 #define DTU_STATE_CONNECT_ERROR 5
 #define DTU_STATE_STOPPED 6
+#define DTU_STATE_INV_REBOOT 7
 
 #define DTU_ERROR_NO_ERROR 0
 #define DTU_ERROR_NO_TIME 1
@@ -186,6 +187,7 @@ private:
 
     void checkingDataUpdate();
     void checkingForLastDataReceived();
+    void resetDtuGlobalData(uint8_t errorState,uint8_t dtuState);
     boolean cloudPauseActiveControl();
         
     // Protobuf functions

--- a/include/dtuInterface.h
+++ b/include/dtuInterface.h
@@ -58,6 +58,7 @@
 #define DTU_TXRX_STATE_WAIT_GET_ALARMS 8
 #define DTU_TXRX_STATE_WAIT_PERFORMANCE_DATA_MODE 9
 #define DTU_TXRX_STATE_WAIT_REQUEST_ALARMS 10
+#define DTU_TXRX_STATE_WAIT_RESTARTMI 11
 #define DTU_TXRX_STATE_ERROR 99
 
 
@@ -115,6 +116,7 @@ struct inverterData
   uint8_t powerLimit = 254;
   uint8_t powerLimitSet = 101; // init with not possible value for startup
   boolean powerLimitSetUpdate = false;
+  boolean rebootMi = false;
   uint32_t dtuRssi = 0;
   uint32_t wifi_rssi_gateway = 0;
   uint32_t respTimestamp = 1704063600;     // init with start time stamp > 0
@@ -151,6 +153,7 @@ public:
     void getDataUpdate();
     void setPowerLimit(int limit);
     void requestRestartDevice();
+    void requestRestartMi();
     void requestInverterTargetState(boolean OnOff);
     void requestAlarms();
 
@@ -215,7 +218,10 @@ private:
 
     boolean writeReqCommandGetAlarms();
     boolean readRespCommandGetAlarms(pb_istream_t istream);
-    
+
+    boolean writeReqCommandRestartMi();
+    boolean readRespCommandRestartMi(pb_istream_t istream);
+
     const char* serverIP;
     uint16_t serverPort;
     AsyncClient* client;

--- a/include/mqttHandler.h
+++ b/include/mqttHandler.h
@@ -27,6 +27,10 @@ struct PowerLimitSet {
     boolean update = false;
 };
 
+struct RebootMi {
+    boolean reboot = false;
+};
+
 struct RemoteBaseData
 {
   float current = 0;
@@ -80,6 +84,8 @@ public:
 
     PowerLimitSet getPowerLimitSet();
     RemoteInverterData getRemoteInverterData();
+    RebootMi getRebootMi();
+
     void stopConnection(boolean full=false);
 
     static void subscribedMessageArrived(char *topic, byte *payload, unsigned int length);
@@ -110,6 +116,7 @@ private:
 
     PowerLimitSet lastPowerLimitSet;
     RemoteInverterData lastRemoteInverterData;
+    RebootMi rebootMi;
     
     void reconnect();
     boolean initiateDiscoveryMessages(bool autoDiscoveryRemove=false);

--- a/include/web/index_html.h
+++ b/include/web/index_html.h
@@ -8,7 +8,8 @@ static const char *index_html PROGMEM = R"=====(
     <meta name="viewport"
         content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width">
     <link rel="stylesheet" type="text/css" href="style.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+    <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"> -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css">
     <!-- <script src="jquery.min.js"></script> -->
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 </head>
@@ -24,8 +25,13 @@ static const char *index_html PROGMEM = R"=====(
     </div>
     <div class="popup" id="changeSettings">
         <div class="popupHeader">
-            <div class="popupHeaderTitle" id="popHeadTitle">settings <i style="font-size: x-small;float:right;"><a
-                        href="/config" target=_blank>advanced config</a></i>
+            <div class="popupHeaderTitle" id="popHeadTitle">settings
+                <!-- <span style="font-size: small;float:right;"> -->
+                <span style="float:right;">
+                    <i class="fa-solid fa-plug-circle-bolt" onclick="show('#rebootMi')" id="settingsBtn" style="cursor: pointer;" title="Restart micro inverter"></i>
+                    &nbsp;
+                    <a href="/config" target="_blank"><i class="fa-solid fa-gears" title="advanced settings"></i></a>
+                </span>
                 <!-- <h2>settings</h2> -->
             </div>
             <div class="popupHeaderTabs">
@@ -113,8 +119,9 @@ static const char *index_html PROGMEM = R"=====(
                     <input type="password" id="mqttPassword" value="admin12345" required maxlength="64">
                 </div>
                 <div id="mqttMainTopicComment">
-                    MQTT main topic for this dtu: <br><small>(e.g. dtu_12345678 will appear as 'dtu_12345678/grid/U' in the broker -
-                    has to be unique in your setup)</small>
+                    MQTT main topic for this dtu: <br><small>(e.g. dtu_12345678 will appear as 'dtu_12345678/grid/U' in
+                        the broker -
+                        has to be unique in your setup)</small>
                 </div>
                 <div>
                     <input type="text" id="mqttMainTopic" maxlength="64">
@@ -138,8 +145,10 @@ static const char *index_html PROGMEM = R"=====(
                     from a given MQTT broker</small>
             </div>
             <div id="remoteSummaryDisplaySettings">
-                <input type="checkbox" id="remoteSummaryDisplayActive"> run as a remote summary display (Solar Monitor)<br>
-                <small>option to use this device as an remote display based on current data from a given MQTT broker to show PV power and yield of current day</small>
+                <input type="checkbox" id="remoteSummaryDisplayActive"> run as a remote summary display (Solar
+                Monitor)<br>
+                <small>option to use this device as an remote display based on current data from a given MQTT broker to
+                    show PV power and yield of current day</small>
             </div>
             <hr>
             <div id="dtuSettings">
@@ -193,8 +202,11 @@ static const char *index_html PROGMEM = R"=====(
             </div>
         </div>
     </div>
-    <div class="popup" id="rebootMi" style="display: none;">
-        <h2>Reboot Mi</h2>
+    <div class="popup2" id="rebootMi" style="display: none;">
+        <h2><i class="fa-solid fa-plug-circle-bolt"></i> Reboot Micro Inverter</h2>
+        <div style="padding-bottom: 10px;">
+            <small>restarting the micro inverter <br/><br/><i style="font-size: small;">(hint: this not rebooting the communication unit 'dtu')</i></small>
+        </div>
         <div>
             <div style="text-align: center;">
                 <b onclick="rebootMi()" id="btnRebootMi" class="form-button btn" style="opacity: 1;">Reboot Mi</b>
@@ -292,7 +304,8 @@ static const char *index_html PROGMEM = R"=====(
         <div>
             <h2>current dtu warnings</h2>
             <h6>Displays the entries in the DTU sorted by the time they occurred <i id="warningsLastUpdate">(last
-                    updated: 01.01.2024 - 00:00:00)</i><br><i id="warningDetailsHint">... rotate the screen to see more details at the warning entry ...</i></h6>
+                    updated: 01.01.2024 - 00:00:00)</i><br><i id="warningDetailsHint">... rotate the screen to see more
+                    details at the warning entry ...</i></h6>
             <hr>
         </div>
         <div id="activeWarnings" style="flex-grow: 1;padding-bottom: 10px;text-align: center; overflow-y: auto;">
@@ -302,24 +315,26 @@ static const char *index_html PROGMEM = R"=====(
             <b onclick="hide('#warningOverview')" class="form-button btn">close</b>
         </div>
     </div>
-    <div class="popup" id="summaryDisplay" style="flex-direction: column; width: 95%; left: 2.5%; height: 85%; top: 2.5%; background-color: #1c1c1c; border-radius: 10px; border-width: 1px; border-color: #2196f3; border-style: solid; box-shadow: 0px 0px 19px 11px rgb(255 165 0); z-index: 19;">
+    <div class="popup" id="summaryDisplay"
+        style="flex-direction: column; width: 95%; left: 2.5%; height: 85%; top: 2.5%; background-color: #1c1c1c; border-radius: 10px; border-width: 1px; border-color: #2196f3; border-style: solid; box-shadow: 0px 0px 19px 11px rgb(255 165 0); z-index: 19;">
         <div>
             <h2>remote summary display</h2>
             <h6>this dtuGateway is configured as a remote summary display</h6>
-            <i style="font-size: x-small;float:right;">change this in <a href="/config" target=_blank>advanced config</a></i>
+            <i style="font-size: x-small;float:right;">change this in <a href="/config" target=_blank>advanced
+                    config</a></i>
             <br>
             <hr>
         </div>
-            <div>
-                solar monitor
-            </div>
-            <div class="panelValueBox">
-                <p>current PV power</p><br>
-                <b id="grid_power2" class="panelValue valueText">--.- W</b><br><br>
-                <small class="panelHead">solar yield today</small><br><br>
-                <b id="grid_daily_energy2" class="panelValueSmall valueText">00.0 </b>kWh<br>
-            </div>
+        <div>
+            solar monitor
         </div>
+        <div class="panelValueBox">
+            <p>current PV power</p><br>
+            <b id="grid_power2" class="panelValue valueText">--.- W</b><br><br>
+            <small class="panelHead">solar yield today</small><br><br>
+            <b id="grid_daily_energy2" class="panelValueSmall valueText">00.0 </b>kWh<br>
+        </div>
+    </div>
     </div>
     <div id="frame">
         <div class="header">
@@ -495,15 +510,12 @@ static const char *index_html PROGMEM = R"=====(
             </div>
             <div id="footer_right">
                 <div class="menuButton notification">
-                    <i class="fa fa-cloud-download" onclick="show('#updateMenu')" alt="update" id="updateBtn"></i>
+                    <i class="fa-solid fa-cloud-download" onclick="show('#updateMenu')" alt="update" id="updateBtn"></i>
                     <span class="badge" id="updateBadge" style="display: none;"></span>
                 </div>
                 <div class="menuButton notification">
-                    <i class="fa fa-sliders" onclick="show('#changeSettings')" alt="settings" id="settingsBtn"></i>
-                    <!-- <span class="badge">0</span> -->
-                </div>
-                <div class="menuButton notification">
-                    <i class="fa fa-close" onclick="show('#rebootMi')" alt="reboot" id="settingsBtn"></i>
+                    <i class="fa-solid fa-sliders" onclick="show('#changeSettings')" alt="settings"
+                        id="settingsBtn"></i>
                     <!-- <span class="badge">0</span> -->
                 </div>
             </div>
@@ -796,7 +808,7 @@ static const char *index_html PROGMEM = R"=====(
                 $("#title").text(gridP + "W - dtuGateway");
             }
 
-            if(data.dtuConnection.dtuRemoteSummaryDisplay) {
+            if (data.dtuConnection.dtuRemoteSummaryDisplay) {
                 $('#summaryDisplay').css('display', 'flex');
                 $('#summaryDisplay').css('flex-direction', 'column');
                 $('#summaryDisplay').css('align-items', 'center');
@@ -1033,7 +1045,7 @@ static const char *index_html PROGMEM = R"=====(
                 remoteSummaryDisplayActiveSend = 1;
             else
                 remoteSummaryDisplayActiveSend = 0;
-            
+
             var data = {};
             data["dtuHostIpDomainSend"] = dtuHostIpDomainSend;
             data["dtuDataCycleSend"] = dtuDataCycleSend;
@@ -1666,8 +1678,7 @@ static const char *index_html PROGMEM = R"=====(
             var iconElement = document.createElement('i');
             iconElement.className = 'fa';
             document.body.appendChild(iconElement);
-            // Check if the 'fa' class is applied, indicating successful loading
-            if (window.getComputedStyle(iconElement).fontFamily !== 'FontAwesome') {
+            if (!window.getComputedStyle(iconElement).fontFamily.includes('Font Awesome')) {
                 handleFontAwesomeError();
             }
             // Remove the temporary element

--- a/include/web/index_html.h
+++ b/include/web/index_html.h
@@ -746,6 +746,12 @@ static const char *index_html PROGMEM = R"=====(
                 case 5:
                     dtuConnect = "connect error";
                     break;
+                case 6:
+                    dtuConnect = "stopped";
+                    break;
+                case 7:
+                    dtuConnect = "reboot inverter";
+                    break;
                 default:
                     dtuConnect = "not known";
             }

--- a/include/web/index_html.h
+++ b/include/web/index_html.h
@@ -193,6 +193,18 @@ static const char *index_html PROGMEM = R"=====(
             </div>
         </div>
     </div>
+    <div class="popup" id="rebootMi" style="display: none;">
+        <h2>Reboot Mi</h2>
+        <div>
+            <div style="text-align: center;">
+                <b onclick="rebootMi()" id="btnRebootMi" class="form-button btn" style="opacity: 1;">Reboot Mi</b>
+            </div>
+
+            <div style="text-align: center;">
+                <b onclick="hide('#rebootMi')" class="form-button btn">close</b>
+            </div>
+        </div>
+    </div>
     <div class="popup" id="updateMenu">
         <h2>Update</h2>
         <h6 id="chipType">controller architecture type: ...</h6>
@@ -488,6 +500,10 @@ static const char *index_html PROGMEM = R"=====(
                 </div>
                 <div class="menuButton notification">
                     <i class="fa fa-sliders" onclick="show('#changeSettings')" alt="settings" id="settingsBtn"></i>
+                    <!-- <span class="badge">0</span> -->
+                </div>
+                <div class="menuButton notification">
+                    <i class="fa fa-close" onclick="show('#rebootMi')" alt="reboot" id="settingsBtn"></i>
                     <!-- <span class="badge">0</span> -->
                 </div>
             </div>
@@ -1157,6 +1173,35 @@ static const char *index_html PROGMEM = R"=====(
             }
 
             hide('#changeSettings');
+            return;
+        }
+
+        function rebootMi() {
+            var data = {};
+            data["rebootMi"] = true;
+            console.log("send to server: rebootMi");
+            const urlEncodedDataPairs = [];
+
+            // Turn the data object into an array of URL-encoded key/value pairs.
+            for (const [name, value] of Object.entries(data)) {
+                urlEncodedDataPairs.push(
+                    `${encodeURIComponent(name)}=${encodeURIComponent(value)}`,
+                );
+            }
+
+            // Combine the pairs into a single string and replace all %-encoded spaces to
+            // the '+' character; matches the behavior of browser form submissions.
+            const urlEncodedData = urlEncodedDataPairs.join("&").replace(/%20/g, "+");
+
+
+            var xmlHttp = new XMLHttpRequest();
+            xmlHttp.open("POST", "/rebootMi", false); // false for synchronous request
+            xmlHttp.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+
+            // Finally, send our data.
+            xmlHttp.send(urlEncodedData);
+
+            hide('#rebootMi')
             return;
         }
 

--- a/include/web/index_html.h
+++ b/include/web/index_html.h
@@ -28,7 +28,7 @@ static const char *index_html PROGMEM = R"=====(
             <div class="popupHeaderTitle" id="popHeadTitle">settings
                 <!-- <span style="font-size: small;float:right;"> -->
                 <span style="float:right;">
-                    <i class="fa-solid fa-plug-circle-bolt" onclick="show('#rebootMi')" id="settingsBtn" style="cursor: pointer;" title="Restart micro inverter"></i>
+                    <i class="fa-solid fa-plug-circle-bolt" onclick="hide('#changeSettings');show('#rebootMi')" id="showRebootMiBtn" style="cursor: pointer;" title="Restart micro inverter"></i>
                     &nbsp;
                     <a href="/config" target="_blank"><i class="fa-solid fa-gears" title="advanced settings"></i></a>
                 </span>

--- a/include/web/style_css.h
+++ b/include/web/style_css.h
@@ -1,5 +1,6 @@
 static const char *style_css PROGMEM = R"=====(
 
+
 * {
     box-sizing: border-box;
 }
@@ -341,6 +342,49 @@ hr {
     font-size: 2.4vmin;
 }
 
+.popup2 {
+    display: none;
+    position: absolute;
+    padding: 25px;
+    width: 40%;
+    left: 30%;
+    height: 60%;
+    top: 20%;
+    /* background: #a5a4a4;
+    border-width: 1px;
+    border-color: #2196f3;
+    border-style: solid;
+    border-radius: 10px; */
+    z-index: 20;
+    font-size: 2.4vmin;
+}
+
+.popup2:after {
+    position: fixed;
+    content: "";
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    background: rgba(0, 0, 0, 0.8);
+    z-index: -2;
+}
+
+.popup2:before {
+    position: absolute;
+    content: "";
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    background: #4e4e4e;
+    border-width: 1px;
+    border-color: #2196f3;
+    border-style: solid;
+    border-radius: 10px;
+    z-index: -1;
+}
+
 /* .popup>.popupHeader>.selected { */
 /* .popup>.popupHeader { */
 .popupHeader {
@@ -424,32 +468,6 @@ hr {
     border-right: 1px solid;
     border-bottom: 1px solid;
     border-radius: 0px 0px 5px 5px;
-}
-
-#popup2:after {
-    position: fixed;
-    content: "";
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
-    background: rgba(0, 0, 0, 0.5);
-    z-index: -2;
-}
-
-#popup2:before {
-    position: absolute;
-    content: "";
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
-    background: #FFF;
-    border-width: 1px;
-    border-color: #2196f3;
-    border-style: solid;
-    border-radius: 10px;
-    z-index: -1;
 }
 
 .tableCell {
@@ -775,6 +793,13 @@ input:checked+.slider:before {
     }
     #warningDetailsHint {
         display: block;
+    }
+
+    .popup2 {
+        width: 80%;
+        left: 10%;
+        height: 60%;
+        top: 20%;
     }
 }
 

--- a/readme.md
+++ b/readme.md
@@ -369,6 +369,7 @@ This branch will be maintained with small bug fix, if needed.
   - the incoming value will be checked for this interval and locally corrected to 2 or 100 if exceeds
   - with retain flag, to get the last set value after restart / reconnect of the dtuGateway
 - to reboot the Mictroinverter
+  - The hoymiles inverter has a micro inverter attached to a dtu. The micro inverter handles mains and solarpanels, while the dtu communicates states and control the mi. Dtu is rebooted if an error occure. Sometimes it is also nessesary to reboot the micro inverter itself.
   - you have to publish to `<main topic>/inverter/RebootMi/set` a value of 1
   - the incoming value will be checked for 1 and reboot the micro inverter
   - this is useful if after a mains power fail the inverter is not injecting power to mains in time

--- a/readme.md
+++ b/readme.md
@@ -368,6 +368,11 @@ This branch will be maintained with small bug fix, if needed.
   - you have to publish to `<main topic>/inverter/PowerLimitSet` a value between 2...100 (possible range at DTU)
   - the incoming value will be checked for this interval and locally corrected to 2 or 100 if exceeds
   - with retain flag, to get the last set value after restart / reconnect of the dtuGateway
+- to reboot the Mictroinverter
+  - you have to publish to `<main topic>/inverter/RebootMi/set` a value of 1
+  - the incoming value will be checked for 1 and reboot the micro inverter
+  - this is useful if after a mains power fail the inverter is not injecting power to mains in time
+  - it could also useful in other scenarios where the micro inverter is in some error state
 - data will be published as following ('dtuGateway_12345678' is configurable in the settings):
   <details>
   <summary>expand to see to details</summary>

--- a/src/base/webserver.cpp
+++ b/src/base/webserver.cpp
@@ -78,6 +78,7 @@ void DTUwebserver::start()
 
     // direct settings
     asyncDtuWebServer.on("/updatePowerLimit", handleUpdatePowerLimit);
+    asyncDtuWebServer.on("/rebootMi", handleRebootMi);
     asyncDtuWebServer.on("/getWifiNetworks", handleGetWifiNetworks);
 
     // api GETs
@@ -668,6 +669,30 @@ void DTUwebserver::handleUpdatePowerLimit(AsyncWebServerRequest *request)
     else
     {
         request->send(400, "text/plain", "handleUpdatePowerLimit - ERROR requested without the expected params");
+        Serial.println(F("WEB:\t\t handleUpdatePowerLimit - ERROR without the expected params"));
+    }
+}
+
+void DTUwebserver::handleRebootMi(AsyncWebServerRequest *request)
+{
+    if (request->hasParam("rebootMi", true))
+    {
+        Serial.println("WEB:\t\t handleRebootMi");
+
+        dtuGlobalData.rebootMi = true;
+
+        Serial.println("WEB:\t\t got Reboot");
+
+        String JSON = "{";
+        JSON = JSON + "\"RebootMi\": true";
+        JSON = JSON + "}";
+
+        request->send(200, "application/json", JSON);
+        Serial.println("WEB:\t\t handleRebootMi - send JSON: " + String(JSON));
+    }
+    else
+    {
+        request->send(400, "text/plain", "handleRebootMi - ERROR requested without the expected params");
         Serial.println(F("WEB:\t\t handleUpdatePowerLimit - ERROR without the expected params"));
     }
 }

--- a/src/dtuGateway.ino
+++ b/src/dtuGateway.ino
@@ -1095,6 +1095,15 @@ void getSerialCommand(String cmd, String value)
       dtuInterface.requestRestartDevice();
     }
   }
+  else if (cmd == "rebootMi") // cmd: 'rebootMi 1'
+  {
+    Serial.print(F(" rebootMi "));
+    if (val == 1)
+    {
+      Serial.println(F(" request Mi reboot at DTUinterface ... "));
+      dtuInterface.requestRestartMi();
+    }
+  }
   else if (cmd == "dtuInverter") // cmd: 'dtuInverter 1' or 'dtuInverter 0'
   {
     Serial.print(F(" dtu inverter "));
@@ -1247,11 +1256,22 @@ void loop()
         dtuGlobalData.powerLimitSetUpdate = true;
         Serial.println("\nMQTT:\t changed powerset value to '" + String(dtuGlobalData.powerLimitSet) + "'");
       }
+      RebootMi rebootMi = mqttHandler.getRebootMi();
+      if (rebootMi.reboot == true)
+      {
+        dtuGlobalData.rebootMi = true;
+        Serial.println("\nMQTT:\t reboot mi");
+      }
       if (dtuGlobalData.powerLimitSetUpdate)
       {
         mqttHandler.publishStandardData("inverter_PowerLimitSet", String(dtuGlobalData.powerLimitSet));
         // postMessageToOpenhab(String(userConfig.openItemPrefix) + "_PowerLimitSet", (String)dtuGlobalData.powerLimit);
         dtuGlobalData.powerLimitSetUpdate = false;
+      }
+      if (dtuGlobalData.rebootMi)
+      {
+        mqttHandler.publishStandardData("inverter_RebootMi", String(1));
+        // postMessageToOpenhab(String(userConfig.openItemPrefix) + "_PowerLimitSet", (String)dtuGlobalData.powerLimit);
       }
 
       RemoteInverterData remoteData = mqttHandler.getRemoteInverterData();
@@ -1359,6 +1379,11 @@ void loop()
           if (dtuGlobalData.currentTimestamp - dtuGlobalData.lastRespTimestamp < (userConfig.dtuUpdateTime * 2))
             platformData.dtuNextUpdateCounterSeconds = dtuGlobalData.currentTimestamp - userConfig.dtuUpdateTime + 5;
         }
+      }
+      if (dtuGlobalData.rebootMi) {
+          dtuGlobalData.rebootMi = false;
+          Serial.println("----- ----- reboot mi ----- ----- ");
+          dtuInterface.requestRestartMi();
       }
     }
 

--- a/src/dtuInterface.cpp
+++ b/src/dtuInterface.cpp
@@ -129,6 +129,19 @@ void DTUInterface::requestRestartDevice()
     }
 }
 
+void DTUInterface::requestRestartMi()
+{
+    if (client->connected())
+    {
+        Serial.println(F("DTUinterface:\t requestRestartDevice - send command to DTU ..."));
+        writeReqCommandRestartMi();
+    }
+    else
+    {
+        Serial.println(F("DTUinterface:\t requestRestartDevice - client not connected."));
+    }
+}
+
 void DTUInterface::requestInverterTargetState(boolean OnOff)
 {
     if (client->connected())
@@ -456,6 +469,9 @@ void DTUInterface::onDataReceived(void *arg, AsyncClient *client, void *data, si
         dtuInterface->readRespCommandRequestAlarms(istream);
         // after request cmd get alarms list
         dtuInterface->writeReqCommandGetAlarms();
+        break;
+    case DTU_TXRX_STATE_WAIT_RESTARTMI:
+        dtuInterface->readRespCommandRestartMi(istream);
         break;
     default:
         Serial.println(F("DTUinterface:\t onDataReceived - no valid or known state"));
@@ -1130,6 +1146,75 @@ boolean DTUInterface::readRespCommandSetPowerlimit(pb_istream_t istream)
 
     return true;
 }
+boolean DTUInterface::writeReqCommandRestartMi()
+{
+    if (!client->connected())
+    {
+        Serial.println(F("DTUinterface:\t writeReqCommandRestartMi - not possible - currently not connect"));
+        return false;
+    }
+
+    // request message
+    uint8_t buffer[200];
+    pb_ostream_t stream = pb_ostream_from_buffer(buffer, sizeof(buffer));
+
+    CommandResDTO commandresdto = CommandResDTO_init_default;
+    // commandresdto.time = int32_t(locTimeSec);
+
+    commandresdto.action = CMD_ACTION_MI_REBOOT;
+    commandresdto.package_nub = 1;
+    commandresdto.tid = int32_t(dtuGlobalData.currentTimestamp);
+
+    bool status = pb_encode(&stream, CommandResDTO_fields, &commandresdto);
+
+    if (!status)
+    {
+        Serial.println(F("DTUinterface:\t writeReqCommandRestartDevice - failed to encode"));
+        return false;
+    }
+
+    // Serial.print(F("\nencoded: "));
+    for (unsigned int i = 0; i < stream.bytes_written; i++)
+    {
+        // Serial.printf("%02X", buffer[i]);
+        crc.add(buffer[i]);
+    }
+
+    uint8_t header[10];
+    header[0] = 0x48;
+    header[1] = 0x4d;
+    header[2] = 0x23; // Command = 0x23 - CMD_CLOUD_COMMAND_RES_DTO = b"\x23\x05"
+    header[3] = 0x05; // Command = 0x05
+    header[4] = 0x00;
+    header[5] = 0x01;
+    header[6] = (crc.calc() >> 8) & 0xFF;
+    header[7] = (crc.calc()) & 0xFF;
+    header[8] = ((stream.bytes_written + 10) >> 8) & 0xFF; // suggest parentheses around '+' inside '>>' [-Wparentheses]
+    header[9] = (stream.bytes_written + 10) & 0xFF;        // warning: suggest parentheses around '+' in operand of '&' [-Wparentheses]
+    crc.restart();
+
+    uint8_t message[10 + stream.bytes_written];
+    for (int i = 0; i < 10; i++)
+    {
+        message[i] = header[i];
+    }
+    for (unsigned int i = 0; i < stream.bytes_written; i++)
+    {
+        message[i + 10] = buffer[i];
+    }
+
+    // Serial.print(F("\nRequest: "));
+    // for (int i = 0; i < 10 + stream.bytes_written; i++)
+    // {
+    //   Serial.print(message[i]);
+    // }
+    // Serial.println("");
+
+    Serial.println(F("DTUinterface:\t writeReqCommandRestartMi --- send request to DTU ..."));
+    dtuConnection.dtuTxRxState = DTU_TXRX_STATE_WAIT_RESTARTMI;
+    client->write((const char *)message, 10 + stream.bytes_written);
+    return true;
+}
 
 boolean DTUInterface::writeReqCommandRestartDevice()
 {
@@ -1207,6 +1292,22 @@ boolean DTUInterface::readRespCommandRestartDevice(pb_istream_t istream)
     CommandReqDTO commandreqdto = CommandReqDTO_init_default;
 
     Serial.print("DTUinterface:\t readRespCommandRestartDevice - got response -> timestamp: " + getTimeStringByTimestamp(commandreqdto.time));
+
+    pb_decode(&istream, &GetConfigReqDTO_msg, &commandreqdto);
+    Serial.printf("\ncommand req action: %i", commandreqdto.action);
+    Serial.printf("\ncommand req: %s", commandreqdto.dtu_sn);
+    Serial.printf("\ncommand req: %i", commandreqdto.err_code);
+    Serial.printf("\ncommand req: %i", commandreqdto.package_now);
+    Serial.printf("\ncommand req: %i", int(commandreqdto.tid));
+    Serial.printf("\ncommand req time: %i", commandreqdto.time);
+    return true;
+}
+boolean DTUInterface::readRespCommandRestartMi(pb_istream_t istream)
+{
+    dtuConnection.dtuTxRxState = DTU_TXRX_STATE_IDLE;
+    CommandReqDTO commandreqdto = CommandReqDTO_init_default;
+
+    Serial.print("DTUinterface:\t readRespCommandRestartMi - got response -> timestamp: " + getTimeStringByTimestamp(commandreqdto.time));
 
     pb_decode(&istream, &GetConfigReqDTO_msg, &commandreqdto);
     Serial.printf("\ncommand req action: %i", commandreqdto.action);

--- a/src/mqttHandler.cpp
+++ b/src/mqttHandler.cpp
@@ -223,6 +223,8 @@ void MQTTHandler::publishDiscoveryMessage(const char *entity, const char *entity
         entityType = "number";
     else if (String(deviceClass).indexOf("running") > -1)
         entityType = "binary_sensor";
+    else if (String(entity).indexOf("Reboot") > -1)
+        entityType = "button";
     String uniqueID = String(deviceGroupName) + "_" + String(entity);
     String entityGroup = String(entity).substring(0, String(entity).indexOf("_"));
     String entityName = String(entity).substring(String(entity).indexOf("_") + 1);
@@ -248,7 +250,13 @@ void MQTTHandler::publishDiscoveryMessage(const char *entity, const char *entity
         doc["min"] = 0;
         doc["max"] = 100;
     }
-    doc["state_topic"] = stateTopicPath;
+
+    if (entityType == "button") {
+        doc["command_topic"] = commandTopicPath;
+        doc["payload_press"] = "1";
+    } else {
+        doc["state_topic"] = stateTopicPath;
+    }
 
     if (deviceClass != NULL)
     {
@@ -351,6 +359,7 @@ boolean MQTTHandler::initiateDiscoveryMessages(bool autoDiscoveryRemove)
 
             publishDiscoveryMessage("inverter_PowerLimit", "power limit", "%", autoDiscoveryRemove, NULL, "power_factor"); //"mdi:car-speed-limiter"
             publishDiscoveryMessage("inverter_PowerLimitSet", "power limit set", "%", autoDiscoveryRemove, "mdi:car-speed-limiter", "power_factor");
+            publishDiscoveryMessage("inverter_RebootMi", "Reboot Micro Inverter", NULL, autoDiscoveryRemove, "mdi:restart", "restart", true);
 
             publishDiscoveryMessage("inverter_Temp", "Inverter temperature", "°C", autoDiscoveryRemove, NULL, "temperature", true); //"mdi:thermometer"
             publishDiscoveryMessage("inverter_WifiRSSI", "WiFi strength", "%", autoDiscoveryRemove, "mdi:wifi", NULL, true);

--- a/src/mqttHandler.cpp
+++ b/src/mqttHandler.cpp
@@ -46,6 +46,15 @@ void MQTTHandler::subscribedMessageArrived(char *topic, byte *payload, unsigned 
             instance->lastPowerLimitSet.setValue = setLimit;
             instance->lastPowerLimitSet.update = true;
         }
+        else if (String(topic) == instance->mqttMainTopicPath + "/inverter/RebootMi/set")
+        {
+
+            int gotReboot = (incommingMessage).toInt();
+            if (gotReboot == 1)
+            {
+                instance->rebootMi.reboot = true;
+            }
+        }
         else
         {
             // Serial.println("MQTT: received message for topic: " + String(topic) + " - value: " + incommingMessage);
@@ -172,6 +181,13 @@ RemoteInverterData MQTTHandler::getRemoteInverterData()
     RemoteInverterData lastReceive = lastRemoteInverterData;
     lastRemoteInverterData.updateReceived = false;
     return lastReceive;
+}
+
+RebootMi MQTTHandler::getRebootMi()
+{
+    RebootMi reboot = rebootMi;
+    rebootMi.reboot = false;
+    return reboot;
 }
 
 void MQTTHandler::setup()
@@ -433,6 +449,9 @@ void MQTTHandler::reconnect()
                 client.subscribe(topic.c_str());
                 Serial.println("MQTT:\t\t subscribe to: " + topic);
                 topic = "homeassistant/number/" + instance->mqttMainTopicPath + "/inverter_PowerLimitSet/set";
+                client.subscribe(topic.c_str());
+                Serial.println("MQTT:\t\t subscribe to: " + topic);
+                topic = mqttMainTopicPath + "/inverter/RebootMi/set";
                 client.subscribe(topic.c_str());
                 Serial.println("MQTT:\t\t subscribe to: " + topic);
 


### PR DESCRIPTION
In my setup with battery instead of solarpanel and a shelly switching mains, it is needed to restart the mi after setting mains to on.
If I not doing so, mi needs forever to enable.

Restart dtu is not enough to solve this.

This patch makes it possible to reboot mi by mqtt and web.