### PR TITLE
Setup Espressif32 version

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp32]
-platform = espressif32
+platform = espressif32@ ^6.11.0
 board = esp32dev
 framework = arduino
 monitor_speed = 115200
@@ -61,7 +61,7 @@ build_flags =
 	-DSPI_FREQUENCY=27000000
 
 [env:esp32_S3]
-platform = espressif32
+platform = espressif32@ ^6.11.0
 board = esp32-s3-devkitc-1
 framework = arduino
 monitor_speed = 115200


### PR DESCRIPTION
Setup minimal version for Espressif32.

Project does not build without this patch in my Visual Studio Code.
I have multiple versions of Espressif32 installed.