### PR TITLE
Test dtu connect weak connection

### DIFF
--- a/include/proto/APPInformationData.options
+++ b/include/proto/APPInformationData.options
@@ -1,0 +1,13 @@
+# Options for APPInformationData.proto nanopb generation
+APPDtuInfoMO.gprs_vsn         max_length:16
+APPDtuInfoMO.wifi_version     max_length:16
+APPDtuInfoMO.ka_nub           max_length:16
+APPDtuInfoMO.gprs_imei        max_length:32
+APPMeterInfoMO.meter_val      max_length:32
+APPFeatureMO.value            max_length:32
+APPInfoDataReqDTO.dtu_sn      max_length:16
+APPInfoDataReqDTO.mAPPMeterInfo max_count:2
+APPInfoDataReqDTO.mAPPRpInfo  max_count:2
+APPInfoDataReqDTO.mAPPpvInfo  max_count:2
+APPInfoDataReqDTO.m_app_feature max_count:5
+APPInfoDataResDTO.ymd_hms     max_length:32

--- a/include/proto/APPInformationData.proto
+++ b/include/proto/APPInformationData.proto
@@ -1,0 +1,89 @@
+syntax = "proto3";
+
+message APPDtuInfoMO {
+  int32 device_kind = 1;
+  int32 dtu_sw_version = 2;
+  int32 dtu_hw_version = 3;
+  int32 dtu_step_time = 4;
+  int32 dtu_rf_hw = 5;
+  int32 dtu_rf_sw = 6;
+  int32 access_model = 7;
+  int32 communication_time = 8;
+  int32 signal_strength = 9;
+  string gprs_vsn = 10;
+  string wifi_version = 11;
+  string ka_nub = 12;
+  int32 dtu_rule_id = 13;
+  int32 dtu_error_code = 14;
+  int32 dtu485_mode = 15;
+  int32 dtu485_addr = 16;
+  int32 sub1g_fqband = 17;
+  int32 sub1g_chtnum = 18;
+  int32 sub1g_chnum = 19;
+  int32 sub1g_rp = 20;
+  int32 sub1g_chtotal = 21;
+  string gprs_imei = 22;
+  int32 dfs = 23;
+}
+
+message APPMeterInfoMO {
+  int32 device_kind = 1;
+  int64 meter_sn = 2;
+  int32 meter_model = 3;
+  int32 meter_ct = 4;
+  int32 com_way = 5;
+  int32 access_mode = 6;
+  int32 sw_vsn = 7;
+  string meter_val = 8;
+}
+
+message APPRpInfoMO {
+  int32 device_kind = 1;
+  int64 rp_sn = 2;
+  int32 rp_sw = 3;
+  int32 rp_hw = 4;
+  int32 rp_rule_id = 5;
+}
+
+message APPPvInfoMO {
+  int32 device_kind = 1;
+  int64 pv_sn = 2;
+  int32 pv_usfw = 3;
+  int32 pv_sw_version = 4;
+  int32 pv_hw_pn = 5;
+  int32 pv_hw_version = 6;
+  int32 pv_gpf_code = 7;
+  int32 pv_gpf = 8;
+  int32 pv_rf_hw = 9;
+  int32 pv_rf_sw = 10;
+  int32 mi_rule_id = 11;
+}
+
+message APPFeatureMO {
+  int32 key = 1;
+  string value = 2;
+}
+
+message APPInfoDataReqDTO {
+  string dtu_sn = 1;       // Serial number of the device
+  uint32 time = 2;
+  int32 device_nub = 3;
+  int32 pv_nub = 4;
+  int32 package_nub = 5;
+  int32 package_now = 6;
+  int32 channel = 7;
+  optional APPDtuInfoMO mAPPDtuInfo = 8;
+  repeated APPMeterInfoMO mAPPMeterInfo = 9;
+  repeated APPRpInfoMO mAPPRpInfo = 10;
+  repeated APPPvInfoMO mAPPpvInfo = 11;
+  uint32 mf = 12;
+  repeated APPFeatureMO m_app_feature = 13;
+}
+
+message APPInfoDataResDTO {
+  string ymd_hms = 1;
+  int32 offset = 2;
+  int32 package_now = 3;
+  int32 err_code = 4;
+  uint32 time = 5;
+}

--- a/include/version.h
+++ b/include/version.h
@@ -1,3 +1,3 @@
-#define VERSION "2.2.349_localDev"
-#define BUILDTIME "20.08.2025 - 22:06:16"
-#define BUILDTIMESTAMP "1755720376"
+#define VERSION "2.2.509_localDev"
+#define BUILDTIME "01.09.2025 - 12:57:23"
+#define BUILDTIMESTAMP "1756724243"

--- a/include/version.json
+++ b/include/version.json
@@ -1,6 +1,6 @@
 {
-    "version": "2.2.349_localDev",
-    "versiondate": "20.08.2025 - 22:06:16",
-    "linksnapshot": "https://github.com/ohAnd/dtuGateway/releases/download/snapshot/dtuGateway_snapshot_2.2.349_localDev.bin",
-    "link": "https://github.com/ohAnd/dtuGateway/releases/latest/download/dtuGateway_release_2.2.349_localDev.bin"
+    "version": "2.2.509_localDev",
+    "versiondate": "01.09.2025 - 12:57:23",
+    "linksnapshot": "https://github.com/ohAnd/dtuGateway/releases/download/snapshot/dtuGateway_snapshot_2.2.509_localDev.bin",
+    "link": "https://github.com/ohAnd/dtuGateway/releases/latest/download/dtuGateway_release_2.2.509_localDev.bin"
 }

--- a/include/web/index_html.h
+++ b/include/web/index_html.h
@@ -874,7 +874,7 @@ static const char *index_html PROGMEM = R"=====(
             var wifiDTUPercent = Math.round(data.dtuConnection.dtuRssi);
             $('#rssitext_dtu').html(wifiDTUPercent + '%');
 
-            $('#firmware').html("fw version: " + data.firmware.version);
+            $('#firmware').html("fw version: " + data.firmware.version + "<br><span style=\"font-size: smaller;\">DTU: " + data.dtuConnection.firmware.dtu_version_string + " | MI: " + data.dtuConnection.firmware.inverter_version_string + "</span>");
             $('#chipType').html("controller architecture type: " + data.chipType);
 
             if (data.firmware.selectedUpdateChannel == 0) { $("#relChanStable").addClass("selected"); $("#relChanSnapshot").removeClass("selected"); }

--- a/platformio.ini
+++ b/platformio.ini
@@ -33,6 +33,7 @@ custom_nanopb_protos =
 	+<include/proto/GetConfig.proto>
 	+<include/proto/CommandPB.proto>
 	+<include/proto/AlarmData.proto>
+	+<include/proto/APPInformationData.proto>
 extra_scripts = pre:version_inc.py
 board_build.partitions = custom_partitions.csv
 monitor_filters = 
@@ -85,6 +86,7 @@ custom_nanopb_protos =
 	+<include/proto/GetConfig.proto>
 	+<include/proto/CommandPB.proto>
 	+<include/proto/AlarmData.proto>
+	+<include/proto/APPInformationData.proto>
 extra_scripts = pre:version_inc.py
 board_build.partitions = custom_partitions.csv
 monitor_filters = 
@@ -160,6 +162,7 @@ custom_nanopb_protos =
 	+<include/proto/GetConfig.proto>
 	+<include/proto/CommandPB.proto>
 	+<include/proto/AlarmData.proto>
+	+<include/proto/APPInformationData.proto>
 extra_scripts = pre:version_inc.py
 monitor_filters =
 	esp32_exception_decoder

--- a/src/base/webserver.cpp
+++ b/src/base/webserver.cpp
@@ -415,7 +415,32 @@ void DTUwebserver::handleInfojson(AsyncWebServerRequest *request)
     JSON = JSON + "\"dtuCloudPause\": " + userConfig.dtuCloudPauseActive + ",";
     JSON = JSON + "\"dtuCloudPauseTime\": " + userConfig.dtuCloudPauseTime + ",";
     JSON = JSON + "\"dtuRemoteDisplay\": " + userConfig.remoteDisplayActive + ",";
-    JSON = JSON + "\"dtuRemoteSummaryDisplay\": " + userConfig.remoteSummaryDisplayActive;
+    JSON = JSON + "\"dtuRemoteSummaryDisplay\": " + userConfig.remoteSummaryDisplayActive + ",";
+
+    // ADD FIRMWARE SECTION
+    JSON = JSON + "\"firmware\": {";
+    if (dtuGlobalData.dtuFirmwareVersionValid)
+    {
+        JSON = JSON + "\"dtu_version\": " + String(dtuGlobalData.dtuFirmwareVersion) + ",";
+        JSON = JSON + "\"dtu_version_string\": \"" + DTUInterface::formatDtuVersion(dtuGlobalData.dtuFirmwareVersion) + "\",";
+    }
+    else
+    {
+        JSON = JSON + "\"dtu_version\": null,";
+        JSON = JSON + "\"dtu_version_string\": \"--\",";
+    }
+
+    if (dtuGlobalData.inverterFirmwareVersionValid)
+    {
+        JSON = JSON + "\"inverter_version\": " + String(dtuGlobalData.inverterFirmwareVersion) + ",";
+        JSON = JSON + "\"inverter_version_string\": \"" + DTUInterface::formatPvSoftwareVersion(dtuGlobalData.inverterFirmwareVersion) + "\"";
+    }
+    else
+    {
+        JSON = JSON + "\"inverter_version\": null,";
+        JSON = JSON + "\"inverter_version_string\": \"--\"";
+    }
+    JSON = JSON + "}";
     JSON = JSON + "},";
 
     JSON = JSON + "\"wifiConnection\": {";

--- a/src/dtuGateway.ino
+++ b/src/dtuGateway.ino
@@ -1644,6 +1644,9 @@ void loop()
     // dtuConnection.dtuConnectionOnline = true;
     // dtuConnection.dtuConnectState = DTU_STATE_CONNECTED;
     // dtuGlobalData.inverterControl.stateOn = false;
+
+    // Request device info periodically
+    dtuInterface.requestDeviceInfoPeriodically();
   }
 
   // mid task


### PR DESCRIPTION
This pull request introduces comprehensive device diagnostics and firmware version reporting for both the DTU and inverter, along with improvements to WiFi connection management and enhanced user documentation. The changes add support for extracting, storing, and exposing DTU/inverter firmware and hardware versions via the REST API and web interface, and introduce automatic WiFi reconnection for weak signals. The documentation is updated to reflect these new features and provide guidance on diagnostics and troubleshooting.

**Device Diagnostics & Firmware Version Reporting**
- Added new protobuf definition `APPInformationData.proto` and corresponding nanopb options to support device info extraction (DTU/inverter firmware, hardware versions, etc.) (`include/proto/APPInformationData.proto`, `include/proto/APPInformationData.options`, `platformio.ini`) [[1]](diffhunk://#diff-7581fc0b2674b4ffd24e0dd283ec3b3ee9b6229ad86eafc23f128fa48d53b091R1-R89) [[2]](diffhunk://#diff-623605c426720a6a266ca8609558f9c1f9b3dc03bfb6ce53469f3303f094eccaR1-R13) [[3]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724R36) [[4]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724R89) [[5]](diffhunk://#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724R165)
- Extended `inverterData` struct and `DTUInterface` class to store DTU/inverter firmware versions, validity flags, and periodic device info request logic (`include/dtuInterface.h`, `src/dtuInterface.cpp`, `src/dtuGateway.ino`) [[1]](diffhunk://#diff-89f66b68a01492dddd6914aff99ffbd70db45621c800004d685f5a63dc36ce50R25) [[2]](diffhunk://#diff-89f66b68a01492dddd6914aff99ffbd70db45621c800004d685f5a63dc36ce50R64) [[3]](diffhunk://#diff-89f66b68a01492dddd6914aff99ffbd70db45621c800004d685f5a63dc36ce50R138-R142) [[4]](diffhunk://#diff-89f66b68a01492dddd6914aff99ffbd70db45621c800004d685f5a63dc36ce50R174-R180) [[5]](diffhunk://#diff-89f66b68a01492dddd6914aff99ffbd70db45621c800004d685f5a63dc36ce50R216-R218) [[6]](diffhunk://#diff-89f66b68a01492dddd6914aff99ffbd70db45621c800004d685f5a63dc36ce50R255-R256) [[7]](diffhunk://#diff-4e88d22d05d911ed1e57f96a03466255db418eb08daf7e276ac8fe874d5e0bdcR83-R85) [[8]](diffhunk://#diff-3bea109a8b30a880db508ac5da9a5df35c591f840499bbf8027d05934c8c534eR1647-R1649)
- Exposed firmware version info in the REST API (`/api/info.json`) and web interface, including formatted version strings (`src/base/webserver.cpp`, `include/web/index_html.h`) [[1]](diffhunk://#diff-2af067d778f695c0af34f801841b9496f701f02cb2cc4303eb168f72549e2547L418-R443) [[2]](diffhunk://#diff-717ac1a9f6e35590884a25f964bfd6d8ba8d6405ed316c3ae7865e069b15269eL877-R877)

**WiFi Connection Management**
- Introduced automatic WiFi reconnection for weak signals (below -75 dBm) and updated documentation to reflect this intelligent handling (`readme.md`) [[1]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R73-R74) [[2]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R110-R111) [[3]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R893) [[4]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R1120-R1121) [[5]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L1231-R1268)

**Documentation & API Enhancements**
- Updated `readme.md` with new features, diagnostics instructions, example API responses, and YAML configuration options for connection management and firmware diagnostics [[1]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R86) [[2]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R719-R720) [[3]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L731-R750) [[4]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R779-R787) [[5]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L957-R985) [[6]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L1231-R1268)
