### PR TITLE
Proposed fix for bug in MQTT publishing.

### DIFF
--- a/src/dtuInterface.cpp
+++ b/src/dtuInterface.cpp
@@ -682,6 +682,7 @@ void DTUInterface::checkingDataUpdate()
     {
         dtuGlobalData.uptodate = true;
         dtuConnection.dtuErrorState = DTU_ERROR_NO_ERROR;
+        dtuGlobalData.updateReceived = true;
         // sync local time (in seconds) to DTU time, only if abbrevation about 3 seconds
         if (abs((int(dtuGlobalData.respTimestamp) - int(dtuGlobalData.currentTimestamp))) > 3)
         {


### PR DESCRIPTION
This is a suggested fix for issue #120. It seems like the variable `dtuGlobalData.updateReceived` is not set when a message with a fresh timestamp is received, and this is added in the PR. 